### PR TITLE
Make event properties configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/node
 WORKDIR /app
 
 COPY package.json package-lock.json .
-RUN npm install && npm install -g @angular/cli
+RUN npm install && npm install -g @angular/cli firebase-tools
 
 COPY . .
 

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,7 +4,7 @@
       <button (click)="sidenav.toggle()" mat-icon-button class="menu-icon">
         <mat-icon>menu</mat-icon>
       </button>
-      <span class="noname-toolbar">[BEZEJMENA]</span>
+      <span class="noname-toolbar">[{{ siteName }}]</span>
     </div>
     <span class="user-name" *ngIf="userName">{{ userName }}</span>
   </mat-toolbar>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,9 +10,8 @@ import { Router } from '@angular/router';
 import { Subject, takeUntil, tap } from 'rxjs';
 import { RoutePaths } from './app-routing.module';
 import { AuthService } from './shared/auth.service';
+import { ConfigService } from './shared/config.service';
 import { DatabaseService } from './shared/database.service';
-import { RemoteConfig } from '@angular/fire/remote-config';
-import { getValue } from 'firebase/remote-config';
 
 enum AuthAction {
   Login = 'Login',
@@ -40,8 +39,8 @@ const DEFAULT_MENU = [
 })
 export class AppComponent implements OnDestroy {
   sidnavButtons = DEFAULT_MENU;
-  private remoteConfig: RemoteConfig = inject(RemoteConfig);
-  siteName = getValue(this.remoteConfig, 'website');
+  private configService: ConfigService = inject(ConfigService);
+  siteName: String = "Noname";
   private unsubscribe = new Subject();
   userName: string | null = null;
 
@@ -51,7 +50,6 @@ export class AppComponent implements OnDestroy {
     private readonly router: Router,
     private readonly database: DatabaseService,
   ) {
-    console.log('config', this.remoteConfig);
     console.log('remote', this.siteName);
     this.authService.userData$
       .pipe(
@@ -123,6 +121,12 @@ export class AppComponent implements OnDestroy {
   openDialog(): void {
     this.dialog.open(AppLoginDialogComponent);
   }
+
+  async ngOnInit() {
+    await this.configService.initializeConfig();
+    this.siteName = this.configService.getString('title');
+  }
+
   ngOnDestroy() {
     this.unsubscribe.next(null);
     this.unsubscribe.complete();

--- a/src/app/content/home/home.component.html
+++ b/src/app/content/home/home.component.html
@@ -1,6 +1,6 @@
 <div #homeContainer class="home-container">
-  <p class="home-default">Závěrečná zážitkovka OHB 2024/2025</p>
-  <h2 class="digital">[BEZEJMENA]</h2>
+  <p class="home-default">{{ subtitle }}</p>
+  <h2 class="digital">[{{ title }}]</h2>
   <div class="timer digital" *ngIf="timeLeft$ | async as t; else sorry">
     <span class="countdown"> {{ t.daysToDday }} </span>:
     <span class="countdown"> {{ t.hoursToDday }} </span>:

--- a/src/app/content/home/home.component.ts
+++ b/src/app/content/home/home.component.ts
@@ -3,13 +3,15 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
-  isDevMode,
   OnDestroy,
   ViewChild,
+  inject,
+  isDevMode,
 } from '@angular/core';
 import { interval, Observable } from 'rxjs';
 import { map, shareReplay } from 'rxjs/operators';
 import { zeroPad } from 'src/app/shared/utils';
+import { ConfigService } from 'src/app/shared/config.service';
 
 interface timeComponents {
   milisecondsToDday: string;
@@ -34,6 +36,8 @@ export class HomeComponent implements AfterViewInit, OnDestroy {
       ? document.getElementById('audio-tik-tok')
       : document.createElement('audio');
   bodyElement = document.getElementById('app-body');
+  private configService: ConfigService = inject(ConfigService);
+  public eventStart: Date = new Date();
 
   ngAfterViewInit() {
     if (!isDevMode() && this.audioElement != null) {
@@ -54,7 +58,7 @@ export class HomeComponent implements AfterViewInit, OnDestroy {
   }
 
   calcDateDiff(
-    endDay: Date = new Date('2025-05-07T04:00:00Z'),
+    endDay: Date = this.eventStart,
   ): timeComponents {
     const dDay = endDay.valueOf();
 
@@ -122,6 +126,11 @@ export class HomeComponent implements AfterViewInit, OnDestroy {
       map(x => this.calcDateDiff()),
       shareReplay(1),
     );
+  }
+
+  async ngOnInit() {
+    await this.configService.initializeConfig();
+    this.eventStart = new Date(this.configService.getString('eventStart'));
   }
 
   ngOnDestroy(): void {

--- a/src/app/content/home/home.component.ts
+++ b/src/app/content/home/home.component.ts
@@ -37,6 +37,8 @@ export class HomeComponent implements AfterViewInit, OnDestroy {
       : document.createElement('audio');
   bodyElement = document.getElementById('app-body');
   private configService: ConfigService = inject(ConfigService);
+  public title: String = "Noname";
+  public subtitle: String = "Experience Event 2025";
   public eventStart: Date = new Date();
 
   ngAfterViewInit() {
@@ -130,6 +132,8 @@ export class HomeComponent implements AfterViewInit, OnDestroy {
 
   async ngOnInit() {
     await this.configService.initializeConfig();
+    this.title = this.configService.getString('title');
+    this.subtitle = this.configService.getString('subtitle');
     this.eventStart = new Date(this.configService.getString('eventStart'));
   }
 

--- a/src/app/content/tasks/tasks.component.ts
+++ b/src/app/content/tasks/tasks.component.ts
@@ -24,8 +24,8 @@ export class TasksComponent implements OnInit, OnDestroy {
 
   </div>
 `,
-    startAt: 1683172800000,
-    endAt: 1683547200000,
+    startAt: 1746590400000,
+    endAt: 1746964800000,
     reward: '',
     shown: true,
   };

--- a/src/app/shared/config.service.ts
+++ b/src/app/shared/config.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, inject } from '@angular/core';
+import { FirebaseApp } from '@angular/fire/app';
+import {
+  RemoteConfig,
+  fetchAndActivate,
+  getRemoteConfig,
+  getString,
+  getValue,
+} from 'firebase/remote-config';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ConfigService {
+  private remoteConfig: RemoteConfig;
+  private app: FirebaseApp = inject(FirebaseApp);
+
+  constructor() {
+    this.remoteConfig = getRemoteConfig(this.app);
+    this.remoteConfig.defaultConfig = {
+      "title": "BEZEJMENA",
+      "subtitle": "Závěrečná víkendovka OHB 2024/2025",
+      "eventStart": "2025-05-07T04:00:00Z",
+    };
+    this.remoteConfig.settings.minimumFetchIntervalMillis = 10 * 60 * 1000;
+  }
+
+  async initializeConfig(): Promise<void> {
+    try {
+      await fetchAndActivate(this.remoteConfig);
+      console.log('Remote config fetched and activated');
+    } catch (error) {
+      console.error('Error fetching remote config:', error);
+    }
+  }
+
+  getValue(key: string) {
+    return getValue(this.remoteConfig, key);
+  }
+
+  getString(key: string) {
+    return getString(this.remoteConfig, key);
+  }
+}


### PR DESCRIPTION
Bind site title, description and event start time to Firebase Remote Config.

This is needed during the event to change the event name once decided, and also may ease updating the project for another year's run.