### PR TITLE
Hide menu before event starts

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,7 +1,12 @@
 <div class="app-container">
   <mat-toolbar class="noname-toolbar">
     <div class="left-side">
-      <button (click)="sidenav.toggle()" mat-icon-button class="menu-icon">
+      <button
+        (click)="sidenav.toggle()"
+        *ngIf="eventStarted"
+        mat-icon-button
+        class="menu-icon"
+      >
         <mat-icon>menu</mat-icon>
       </button>
       <span class="noname-toolbar">[{{ siteName }}]</span>
@@ -10,17 +15,19 @@
   </mat-toolbar>
   <mat-sidenav-container class="main-container" hasBackdrop="false">
     <mat-sidenav class="sidenav-container" #sidenav mode="over">
-      <div
-        class="sidenav-buttons"
-        *ngFor="let menu of sidnavButtons; last as isLast"
-      >
-        <div class="menu-item" *ngIf="!isLast" [routerLink]="menu.url">
-          <i class="menu-icon" [ngClass]="menu.icon"></i>
-          <span class="menu-label">{{ menu.title }}</span>
-        </div>
-        <div class="menu-item" *ngIf="isLast" (click)="lastButton(menu.url)">
-          <i class="menu-icon" [ngClass]="menu.icon"></i>
-          <span class="menu-label">{{ menu.title }}</span>
+      <div *ngIf="eventStarted">
+        <div
+          class="sidenav-buttons"
+          *ngFor="let menu of sidnavButtons; last as isLast"
+        >
+          <div class="menu-item" *ngIf="!isLast" [routerLink]="menu.url">
+            <i class="menu-icon" [ngClass]="menu.icon"></i>
+            <span class="menu-label">{{ menu.title }}</span>
+          </div>
+          <div class="menu-item" *ngIf="isLast" (click)="lastButton(menu.url)">
+            <i class="menu-icon" [ngClass]="menu.icon"></i>
+            <span class="menu-label">{{ menu.title }}</span>
+          </div>
         </div>
       </div>
     </mat-sidenav>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -41,6 +41,8 @@ export class AppComponent implements OnDestroy {
   sidnavButtons = DEFAULT_MENU;
   private configService: ConfigService = inject(ConfigService);
   siteName: String = "Noname";
+  eventStart = new Date();
+  eventStarted = false;
   private unsubscribe = new Subject();
   userName: string | null = null;
 
@@ -125,6 +127,8 @@ export class AppComponent implements OnDestroy {
   async ngOnInit() {
     await this.configService.initializeConfig();
     this.siteName = this.configService.getString('title');
+    this.eventStart = new Date(this.configService.getString('eventStart'));
+    this.eventStarted = this.eventStart.valueOf() < Date.now();
   }
 
   ngOnDestroy() {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -43,6 +43,7 @@ export class AppComponent implements OnDestroy {
   siteName: String = "Noname";
   eventStart = new Date();
   eventStarted = false;
+  eventStartedInterval = 0;
   private unsubscribe = new Subject();
   userName: string | null = null;
 
@@ -128,12 +129,17 @@ export class AppComponent implements OnDestroy {
     await this.configService.initializeConfig();
     this.siteName = this.configService.getString('title');
     this.eventStart = new Date(this.configService.getString('eventStart'));
-    this.eventStarted = this.eventStart.valueOf() < Date.now();
+    this.eventStartedInterval = setInterval(() => {
+      this.eventStarted = this.eventStart.valueOf() < Date.now();
+    }, 1000);
   }
 
   ngOnDestroy() {
     this.unsubscribe.next(null);
     this.unsubscribe.complete();
+    if (this.eventStartedInterval) {
+      clearInterval(this.eventStartedInterval);
+    }
   }
 }
 


### PR DESCRIPTION
Before the event starts, the login menu should remain hidden to avoid leaking information early.