### PR TITLE
Use faster configuration refresh on development instance

### DIFF
--- a/src/app/shared/config.service.ts
+++ b/src/app/shared/config.service.ts
@@ -4,6 +4,8 @@ import {
   RemoteConfig,
   fetchAndActivate,
   getRemoteConfig,
+  getBoolean,
+  getNumber,
   getString,
   getValue,
 } from 'firebase/remote-config';
@@ -36,6 +38,14 @@ export class ConfigService {
 
   getValue(key: string) {
     return getValue(this.remoteConfig, key);
+  }
+
+  getBoolean(key: string) {
+    return getBoolean(this.remoteConfig, key);
+  }
+
+  getNumber(key: string) {
+    return getNumber(this.remoteConfig, key);
   }
 
   getString(key: string) {

--- a/src/app/shared/config.service.ts
+++ b/src/app/shared/config.service.ts
@@ -9,6 +9,7 @@ import {
   getString,
   getValue,
 } from 'firebase/remote-config';
+import { environment } from 'src/environments/environment';
 
 @Injectable({
   providedIn: 'root'
@@ -23,8 +24,10 @@ export class ConfigService {
       "title": "BEZEJMENA",
       "subtitle": "Závěrečná víkendovka OHB 2024/2025",
       "eventStart": "2025-05-07T04:00:00Z",
+      "showTaskEnd": "true",
     };
-    this.remoteConfig.settings.minimumFetchIntervalMillis = 10 * 60 * 1000;
+    this.remoteConfig.settings.minimumFetchIntervalMillis
+        = environment.configFetchIntervalMillis;
   }
 
   async initializeConfig(): Promise<void> {

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -8,5 +8,6 @@ export const environment = {
     messagingSenderId: "795449313701",
     appId: "1:795449313701:web:b794b04f38a0a3a4c4c04c",
     measurementId: "G-5TB2BRSB1Y"
-  }
+  },
+  configFetchIntervalMillis: 10 * 1000,
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -8,5 +8,6 @@ export const environment = {
     messagingSenderId: "795449313701",
     appId: "1:795449313701:web:1b11e5f95ce2cd28c4c04c",
     measurementId: "G-GYKZ6WZ1Y2"
-  }
+  },
+  configFetchIntervalMillis: 10 * 60 * 1000,
 };


### PR DESCRIPTION
Make the Remote Config refresh interval configurable by `environment.ts` and provide different value for `development` configuration.