### PR TITLE
Use configurable factors when logging game time and improve UX

### DIFF
--- a/src/app/content/logs/logs.component.html
+++ b/src/app/content/logs/logs.component.html
@@ -39,7 +39,11 @@
             <input matInput type="number" formControlName="time" />
           </mat-form-field>
 
-          <mat-form-field appearance="fill" class="input-filed">
+          <mat-form-field
+            appearance="fill"
+            class="input-filed"
+            *ngIf="logForm.value.logOption !== optionType.Me"
+          >
             <mat-label>Zadavatel/Dárce</mat-label>
             <mat-select formControlName="fromId">
               <mat-option
@@ -53,7 +57,8 @@
           <mat-form-field
             appearance="fill"
             class="input-filed"
-            *ngIf="logForm.value.logOption !== optionType.MyTeam"
+            *ngIf="logForm.value.logOption !== optionType.MyTeam
+                   && logForm.value.logOption !== optionType.Me"
           >
             <mat-label>Kdo dostane čas</mat-label>
             <mat-select formControlName="forId">

--- a/src/app/shared/shared.interface.ts
+++ b/src/app/shared/shared.interface.ts
@@ -59,3 +59,9 @@ export interface UserData {
   dreams: string;
   questionToOthers: string;
 }
+
+export interface ConfigData {
+  timeFactorMyTeam: number;
+  timeFactorGift: number;
+  timeFactorSomeoneOther: number;
+}


### PR DESCRIPTION
Make the factors used to compute game time when logging task completion configurable from Realtime Database.

Also hide the two extra fields (`forId` and `fromId`) when logging one's own task completion. These were unnecessary and confusing for users.